### PR TITLE
Printing preconditioner scaling weights

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -220,9 +220,12 @@ void BaseQNAcceleration::updateDifferenceMatrices(
 
       Eigen::VectorXd deltaR = _residuals;
       deltaR -= _oldResiduals;
+      PRECICE_INFO("deltaR values: " << utils::MasterSlave::l2norm(deltaR));
 
       Eigen::VectorXd deltaXTilde = _values;
+      PRECICE_INFO("Magnitude values: " << utils::MasterSlave::l2norm(_values));
       deltaXTilde -= _oldXTilde;
+      PRECICE_INFO("deltaXTilde values: " << utils::MasterSlave::l2norm(deltaXTilde));
 
       PRECICE_CHECK(not math::equals(utils::MasterSlave::l2norm(deltaR), 0.0), "Attempting to add a zero vector to the quasi-Newton V matrix. This means that the residual "
                                                                                "in two consecutive iterations is identical. There is probably something wrong in your adapter. "
@@ -267,6 +270,43 @@ void BaseQNAcceleration::updateDifferenceMatrices(
   }
 }
 
+/**
+ *        Check if convergence is stagnating
+ * 
+ */
+void BaseQNAcceleration::stagnatingCheck()
+{
+  int kC = _matrixCols[0];
+
+  if (kC > 20 && kC <= 40){
+    double averageFirst = 0.0;
+    double averageLast = 0.0;
+    for (int i = 0; i < 3; i++){
+      Eigen::VectorXd vFirst = _matrixV.col(i);
+      averageFirst += utils::MasterSlave::l2norm(vFirst);
+      Eigen::VectorXd vLast = _matrixV.col(i + 8);
+      averageLast += utils::MasterSlave::l2norm(vLast);
+    }
+    PRECICE_INFO("Convergence Rate for stagnating Check -> 20+: " << averageLast/averageFirst);
+  }
+  if (kC > 40){
+    double averageFirst = 0.0;
+    double averageLast = 0.0;
+    double averageMiddle = 0.0;
+    for (int i = 0; i < 3; i++){
+      Eigen::VectorXd vFirst = _matrixV.col(i);
+      averageFirst += utils::MasterSlave::l2norm(vFirst);
+      Eigen::VectorXd vLast = _matrixV.col(i + 16);
+      averageLast += utils::MasterSlave::l2norm(vLast);
+      Eigen::VectorXd vMiddle = _matrixV.col(i + 8);
+      averageMiddle += utils::MasterSlave::l2norm(vMiddle);
+    }
+    PRECICE_INFO("Convergence Rate for stagnating Check -> 40+: " << averageLast/averageFirst);
+    PRECICE_INFO("Convergence Rate for stagnating Check -> 20+: " << averageMiddle/averageFirst);
+  }
+
+}
+
 /** ---------------------------------------------------------------------------------------------
  *         performAcceleration()
  *
@@ -309,6 +349,7 @@ void BaseQNAcceleration::performAcceleration(
    * appending the difference matrices
    */
   updateDifferenceMatrices(cplData);
+  stagnatingCheck();
 
   if (_firstIteration && (_firstTimeStep || _forceInitialRelaxation)) {
     PRECICE_DEBUG("   Performing underrelaxation");
@@ -365,6 +406,25 @@ void BaseQNAcceleration::performAcceleration(
       _nbDelCols  = 0;
       _nbDropCols = 0;
     }
+
+    if(tSteps == 0){
+      if(its == 3){
+        removeMatrixColumn(2);
+        _qrV.deleteColumn(2);
+      }
+    }else if(tSteps > 1){
+      if(its == 2){
+        removeMatrixColumn(_matrixCols[1]);
+        _qrV.deleteColumn(_matrixCols[1]);
+        removeMatrixColumn(_matrixCols[1] - 1);
+        _qrV.deleteColumn(_matrixCols[1] - 1);
+      }
+    }
+    if(tSteps == 5 && its == 0)
+      _timestepsReused = 10;
+    else if (tSteps < 5)
+      _timestepsReused = 3;
+
 
     // apply the configured filter to the LS system
     applyFilter();
@@ -454,7 +514,7 @@ void BaseQNAcceleration::applyFilter()
 
       removeMatrixColumn(delIndices[i]);
 
-      PRECICE_DEBUG(" Filter: removing column with index " << delIndices[i] << " in iteration " << its << " of time step: " << tSteps);
+      PRECICE_INFO(" Filter: removing column with index " << delIndices[i] << " in iteration " << its << " of time step: " << tSteps);
     }
     PRECICE_ASSERT(_matrixV.cols() == _qrV.cols(), _matrixV.cols(), _qrV.cols());
   }

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -105,8 +105,6 @@ public:
     */
   virtual void performAcceleration(DataMap &cplData);
 
-  virtual void stagnatingCheck();
-
   /**
     * @brief Marks a iteration sequence as converged.
     *

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -105,6 +105,8 @@ public:
     */
   virtual void performAcceleration(DataMap &cplData);
 
+  virtual void stagnatingCheck();
+
   /**
     * @brief Marks a iteration sequence as converged.
     *

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -174,7 +174,7 @@ public:
       if (_nbNonConstTimesteps >= _maxNonConstTimesteps && _maxNonConstTimesteps > 0)
         _freezed = true;
     }
-
+    PRECICE_INFO("Updating precon weights");
     // type specific update functionality
     _update_(timestepComplete, oldValues, res);
   }
@@ -184,6 +184,16 @@ public:
   {
     PRECICE_TRACE(_requireNewQR);
     return _requireNewQR;
+  }
+  
+  bool updatedWeights()
+  {
+    return _updatedWeights;
+  }
+
+  void updatedWeightsReset()
+  {
+    _updatedWeights = false;
   }
 
   /// to tell the preconditioner that QR-decomposition has been recomputed
@@ -222,6 +232,8 @@ protected:
 
   /// True if a QR decomposition from scratch is necessary
   bool _requireNewQR = false;
+
+  bool _updatedWeights = false;
 
   /// True if _nbNonConstTimesteps >= _maxNonConstTimesteps, i.e., preconditioner is not updated any more.
   bool _freezed = false;

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -29,6 +29,36 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
                                          const Eigen::VectorXd &res)
 {
   if (not timestepComplete) {
+    /*
+    if(firstIter){
+      PRECICE_INFO("Using value preconditioner for first step.");
+      std::vector<double> norms(_subVectorSizes.size(), 0.0);
+
+      int offset = 0;
+      for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+        Eigen::VectorXd part = Eigen::VectorXd::Zero(_subVectorSizes[k]);
+        for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+          part(i) = oldValues(i + offset);
+        }
+        norms[k] = utils::MasterSlave::l2norm(part);
+        offset += _subVectorSizes[k];
+        PRECICE_ASSERT(norms[k] > 0.0);
+      }
+
+      offset = 0;
+      for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+        for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+          _weights[i + offset]    = 1.0 / norms[k];
+          _invWeights[i + offset] = norms[k];
+        }
+        offset += _subVectorSizes[k];
+      }
+
+      _requireNewQR  = true;
+      firstIter = false;
+
+    }else{
+      */
     std::vector<double> norms(_subVectorSizes.size(), 0.0);
 
     double sum = 0.0;
@@ -55,16 +85,79 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
     }
 
     offset = 0;
+    normWeights.resize(_subVectorSizes.size());
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-        _weights[i + offset]    = 1 / _residualSum[k];
-        _invWeights[i + offset] = _residualSum[k];
-      }
+      // IF statement checks stops updating the preconditioner weights once the number of time windows goes above a threshold
+      if (tStepPrecon < 2000 ){
+        for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+          _weights[i + offset]    = 1 / _residualSum[k];
+          _invWeights[i + offset] = _residualSum[k];
+        }
+        //_requireNewQR = true;
+      } 
+      normWeights[k] = 1 / _residualSum[k];
+      PRECICE_INFO("Actual Norm of weights: " << _weights[1 + offset]);
+      PRECICE_INFO("Predicted Norm of weights: " << normWeights[k]);
       offset += _subVectorSizes[k];
+      if (k == 0){
+        //if (normWeights[k] > maxWeight)
+          //maxWeight = normWeights[k];
+        //if (normWeights[k] < minWeight && normWeights[k] > 1)
+          //minWeight = normWeights[k];
+      }
+      PRECICE_INFO("Norm of weights: Min " << minWeight << " and Max: " << maxWeight);
     }
+    
+    //PRECICE_INFO("Norm of weights: " << utils::MasterSlave::l2norm(normWeights));
 
     _requireNewQR = true;
-  } else {
+    //_requireNewQR = false;
+    //}
+  }else{
+    /*
+    *  This section reset the preconditioner weights if it changes by more than factor 10 
+    */
+    /*
+    double rationOne = maxWeight/minWeight;
+    double rationTwo = (1 / _residualSum[0])/(1 / _residualSum[1]);
+
+    if(tStepPrecon < 2){                  //Must be same value as line 91
+      maxWeight = 1 / _residualSum[0];
+      minWeight = 1 / _residualSum[1];
+    }
+    if(((maxWeight/(1 / _residualSum[0])) > 10 || (maxWeight/(1 / _residualSum[0])) < 0.1) && (tStepPrecon > 2)){     //Must be same value as line 91
+    //if(((rationOne/rationTwo < 0.1) || (rationOne/rationTwo > 10)) && (tStepPrecon > 7)){
+      PRECICE_INFO("Updated weights MAX during runtime. Will need to reset SVD with ration: " << rationOne/rationTwo);
+      
+      int offset = 0;
+      //for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+        for (size_t i = 0; i < _subVectorSizes[0]; i++) {
+          _weights[i + offset]    = 1 / _residualSum[0];
+          _invWeights[i + offset] = _residualSum[0];
+        }
+        //offset += _subVectorSizes[k];
+      //}
+      
+      maxWeight = 1 / _residualSum[0];
+      _updatedWeights = true;
+    }
+    if(((minWeight/(1 / _residualSum[1])) > 10 || (minWeight/(1 / _residualSum[1])) < 0.1) && (tStepPrecon > 2)){     //Must be same value as line 91
+      PRECICE_INFO("Updated weights MIN during runtime. Will need to reset SVD with ration: " << rationOne/rationTwo);
+      
+      int offset = 0;
+      //for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+        offset += _subVectorSizes[0];
+        for (size_t i = 0; i < _subVectorSizes[1]; i++) {
+          _weights[i + offset]    = 1 / _residualSum[1];
+          _invWeights[i + offset] = _residualSum[1];
+        }
+      //}
+      
+      minWeight = 1 / _residualSum[1];
+      _updatedWeights = true;
+    }
+*/
+    tStepPrecon++;
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       _residualSum[k] = 0.0;
     }

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -25,6 +25,14 @@ public:
 
   virtual void initialize(std::vector<size_t> &svs);
 
+  bool firstIter = true;
+
+  double maxWeight = 0;
+  double minWeight = 1000000000;
+
+  int tStepPrecon = 1;
+  Eigen::VectorXd normWeights;
+
 private:
   /**
    * @brief Update the scaling after every FSI iteration.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -542,6 +542,7 @@ bool BaseCouplingScheme::measureConvergence()
     if (not utils::MasterSlave::isSlave() && convMeasure.doesLogging) {
       _convergenceWriter->writeData(convMeasure.logHeader(), convMeasure.measure->getNormResidual());
     }
+    PRECICE_INFO("Convergence value: " << convMeasure.measure->getNormResidual());
 
     if (not convMeasure.measure->isConvergence()) {
       allConverged = false;

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -542,7 +542,6 @@ bool BaseCouplingScheme::measureConvergence()
     if (not utils::MasterSlave::isSlave() && convMeasure.doesLogging) {
       _convergenceWriter->writeData(convMeasure.logHeader(), convMeasure.measure->getNormResidual());
     }
-    PRECICE_INFO("Convergence value: " << convMeasure.measure->getNormResidual());
 
     if (not convMeasure.measure->isConvergence()) {
       allConverged = false;


### PR DESCRIPTION
## Main changes of this PR

This PR continuously determines the preconditioner weights, even after freezing. In this case, the weights for the QR decomposition are not updated.


## Motivation and additional information

This allows the tracking of weights as the weights must be frozen for the RS-SVD method to work